### PR TITLE
Symbols aggregated in config

### DIFF
--- a/lua/navigator.lua
+++ b/lua/navigator.lua
@@ -1,7 +1,6 @@
 local M = {}
 _NgConfigValues = {
   debug = false, -- log output not implemented
-  code_action_icon = " ",
   width = 0.6, -- valeu of cols TODO allow float e.g. 0.6
   preview_height = 0.35,
   height = nil,
@@ -23,6 +22,33 @@ _NgConfigValues = {
       -- sumneko_binary = sumneko_binary,
       -- cmd = {'lua-language-server'}
     }
+  },
+  icons = {
+    -- Code action
+    code_action_icon = " ",
+    -- Diagnostics
+    diagnostic_head = '🐛',
+    diagnostic_head_severity_1 = "🈲",
+    diagnostic_head_severity_2 = "☣️",
+    diagnostic_head_severity_3 = "👎",
+    diagnostic_head_description = "📛",
+    diagnostic_virtual_text = "🦊",
+    diagnostic_file = "🚑",
+    -- Values
+    value_changed = "📝",
+    value_definition = "🦕",
+    -- Treesitter
+    match_kinds = {
+      var = " ", -- "👹", -- Vampaire
+      method = "ƒ ", --  "🍔", -- mac
+      ["function"] = " ", -- "🤣", -- Fun
+      parameter = "  ", -- Pi
+      associated = "🤝",
+      namespace = "🚀",
+      type = " ",
+      field = "🏈",
+    },
+    treesitter_defult = "🌲",
   }
 }
 

--- a/lua/navigator/codeAction.lua
+++ b/lua/navigator/codeAction.lua
@@ -82,7 +82,7 @@ end
 local sign_name = "NavigatorLightBulb"
 
 if vim.tbl_isempty(vim.fn.sign_getdefined(sign_name)) then
-  vim.fn.sign_define(sign_name, {text = config.code_action_icon, texthl = "LspDiagnosticsSignHint"})
+  vim.fn.sign_define(sign_name, {text = config.icons.code_action_icon, texthl = "LspDiagnosticsSignHint"})
 end
 
 local function _update_virtual_text(line)
@@ -90,7 +90,7 @@ local function _update_virtual_text(line)
   pcall(api.nvim_buf_clear_namespace, 0, namespace, 0, -1)
 
   if line then
-    local icon_with_indent = "  " .. config.code_action_icon
+    local icon_with_indent = "  " .. config.icons.code_action_icon
 
     pcall(
       api.nvim_buf_set_extmark,

--- a/lua/navigator/diagnostics.lua
+++ b/lua/navigator/diagnostics.lua
@@ -31,15 +31,15 @@ local diag_hdlr = function(err, method, result, client_id, br, config)
       item.lnum = v.range.start.line + 1
       item.col = v.range.start.character + 1
       item.uri = uri
-      local head = "🐛"
+      local head = _NgConfigValues.icons.diagnostic_head
       if v.severity == 1 then
-        head = "🈲"
+        head = _NgConfigValues.icons.diagnostic_head_severity_1
       end
       if v.severity == 2 then
-        head = "☣️"
+        head = _NgConfigValues.icons.diagnostic_head_severity_2
       end
       if v.severity > 2 then
-        head = "👎"
+        head = _NgConfigValues.icons.diagnostic_head_severity_3
       end
       local bufnr = vim.uri_to_bufnr(uri)
       vim.fn.bufload(bufnr)
@@ -47,7 +47,7 @@ local diag_hdlr = function(err, method, result, client_id, br, config)
       local row = pos.line
       local line = (vim.api.nvim_buf_get_lines(bufnr, row, row + 1, false) or {""})[1]
       if line ~= nil then
-        item.text = head .. line .. " 📛 " .. v.message
+        item.text = head .. line .. _NgConfigValues.icons.diagnostic_head_description .. v.message
         table.insert(item_list, item)
       else
         error("diagnostic result empty line", v, item)
@@ -66,7 +66,7 @@ M.diagnostic_handler = vim.lsp.with(diag_hdlr, {
   -- Enable virtual text, override spacing to 0
   virtual_text = {
     spacing = 0,
-    prefix = "🦊" -- ' ,   
+    prefix = _NgConfigValues.icons.diagnostic_virtual_text
   },
   -- Use a function to dynamically turn signs off
   -- and on, using buffer local variables
@@ -101,7 +101,7 @@ M.show_diagnostic = function()
     if #display_items > 0 then
       gui.new_list_view({
         items = display_items,
-        api = "🚑🐛 Diagnostic ",
+        api = _NgConfigValues.icons.diagnostic_file .. _NgConfigValues.icons.diagnostic_head .. " Diagnostic ",
         enable_preview_edit = true
       })
     end

--- a/lua/navigator/render.lua
+++ b/lua/navigator/render.lua
@@ -129,11 +129,11 @@ function M.prepare_for_render(items, opts)
     item.text = string.format("%4i: %s", item.lnum, item.text)
     local ts_report = ""
     if item.lhs then
-      ts_report = '📝 '
+      ts_report = _NgConfigValues.icons.value_changed
     end
 
     if item.definition then
-      ts_report = ts_report .. '🦕 '
+      ts_report = ts_report .. _NgConfigValues.icons.value_definition .. ' '
     end
     local header_len = #ts_report + 4 -- magic number 2
     trace(ts_report, header_len)
@@ -149,8 +149,8 @@ function M.prepare_for_render(items, opts)
             endwise = '()'
             local syb = items[i].symbol_name
             if txt == items[i].symbol_name or (#txt > #syb and txt:sub(#txt - #syb + 1) == syb) then
-              if ts_report ~= '🦕 ' then
-                ts_report = ts_report .. '🦕 '
+              if ts_report ~= _NgConfigValues.icons.value_definition .. ' ' then
+                ts_report = ts_report .. _NgConfigValues.icons.value_definition .. ' '
               end
               header_len = #ts_report + 1
             else

--- a/lua/navigator/treesitter.lua
+++ b/lua/navigator/treesitter.lua
@@ -21,22 +21,11 @@ local log = require"navigator.util".log
 local lerr = require"navigator.util".error
 local trace = require"navigator.util".trace
 
-local match_kinds = {
-  var = " ", -- "👹", -- Vampaire
-  method = "ƒ ", --  "🍔", -- mac
-  ["function"] = " ", -- "🤣", -- Fun
-  parameter = "  ", -- Pi
-  associated = "🤝",
-  namespace = "🚀",
-  type = " ",
-  field = "🏈"
-}
-
 local get_icon = function(kind)
-  if kind == nil or match_kinds[kind] == nil then
-    return "🌲"
+  if kind == nil or _NgConfigValues.icons.match_kinds[kind] == nil then
+    return _NgConfigValues.icons.treesitter_defult
   else
-    return match_kinds[kind]
+    return _NgConfigValues.icons.match_kinds[kind]
   end
 end
 -- require'navigator.treesitter'.goto_definition()
@@ -440,7 +429,7 @@ function M.buf_ts()
     ft = ft,
     rawdata = true,
     width = width + 10,
-    api = "🎄"
+    api = _NgConfigValues.icons.treesitter_defult
   })
 end
 
@@ -475,7 +464,7 @@ function M.bufs_ts()
       prompt = true,
       ft = ft,
       width = max_length + 10,
-      api = "🎄"
+      api = _NgConfigValues.icons.treesitter_defult
     })
   end
 end


### PR DESCRIPTION
Hi, love the plugin!

I thought it might be a good idea to place most icon definitions inside the config table so we can more easily change them to what we like. I decided to leave the lspclient symbols inside their own files because the tables are way larger, but all the emoji ones are now inside `_NgConfigValues`.