### PR TITLE
Fix for ]d being mapped to diagnostic.goto_next. 

### DIFF
--- a/lua/navigator/lspclient/mapping.lua
+++ b/lua/navigator/lspclient/mapping.lua
@@ -36,7 +36,7 @@ local key_maps = {
   {key = "gL", func = "diagnostic.show_line_diagnostics( { border = 'single' })"},
   {key = "gG", func = "require('navigator.diagnostics').show_diagnostic()"},
   {key = "]d", func = "diagnostic.goto_next({ border = 'single' })"},
-  {key = "[d", func = "diagnostic.goto_next({ border = 'single' })"},
+  {key = "[d", func = "diagnostic.goto_prev({ border = 'single' })"},
   {key = "]r", func = "require('navigator.treesitter').goto_next_usage()"},
   {key = "[r", func = "require('navigator.treesitter').goto_previous_usage()"},
   {key = "<C-LeftMouse>", func = "definition()"},


### PR DESCRIPTION
diagnostic.goto_next -> diagnostic.goto_prev for [d.