### PR TITLE
Name change lspinstall to nvim-lspinstall in lazy loader

### DIFF
--- a/lua/navigator/lazyloader.lua
+++ b/lua/navigator/lazyloader.lua
@@ -10,7 +10,7 @@ if packer_plugins ~= nil then -- packer install
     ["guihua.lua"] = "ray-x/guihua.lua"
   }
   if _NgConfigValues.lspinstall == true then
-    lazy_plugins["lspinstall"] = "kabouzeid/nvim-lspinstall"
+    lazy_plugins["nvim-lspinstall"] = "kabouzeid/nvim-lspinstall"
   end
 
   -- packer installed


### PR DESCRIPTION
On a clean install, packer compiles down to:

```lua
  ["nvim-lspinstall"] = {
    loaded = true,
    path = "..."
  },
```

rather than 

```lua
  ["lspinstall"] = {
    loaded = true,
    path = "..."
  },
```

without this change, I get a (cosmetic) error on every startup like this:

```
Error: attempted to load lspinstall which is not present in plugins table!                                                                                                                                                                                                                  
Error in packer_compiled: ...m/site/pack/packer/start/packer.nvim/lua/packer/load.lua:13: Error: attempted to load lspinstall which is not present in plugins table!                                                                                                                        
Please check your config for correctness
```

I don't know when/why/how this changed, but with everything updated, this is the only way to get it not to throw the error.