### PR TITLE
Add markdown

### DIFF
--- a/lua/navigator/lspclient/clients.lua
+++ b/lua/navigator/lspclient/clients.lua
@@ -563,7 +563,7 @@ local function setup(user_opts)
   local retry = true
   local disable_ft = {
     "NvimTree", "guihua", "clap_input", "clap_spinner", "vista", "vista_kind", "TelescopePrompt",
-    "csv", "txt", "markdown", "defx"
+    "csv", "txt", "defx"
   }
   for i = 1, #disable_ft do
     if ft == disable_ft[i] or _LoadedFiletypes[ft] then


### PR DESCRIPTION
Hi, thank you for the awesome project.
I note you that now neovim/nvim-lspconfig has the several lsp configurations for Markdown.
So I propose you to drop the `markdown` from the `disable_ft`.

Thank you.