### PR TITLE
Fixes problem with disabling icons not working (#142)

### DIFF
--- a/lua/navigator/diagnostics.lua
+++ b/lua/navigator/diagnostics.lua
@@ -307,7 +307,9 @@ local diagnostic_cfg = {
   -- Enable underline, use default values
   underline = true,
   -- Enable virtual text, override spacing to 3  (prevent overlap)
-  virtual_text = { spacing = 3, prefix = _NgConfigValues.icons.diagnostic_virtual_text },
+  virtual_text = {
+      spacing = 3,
+      prefix = _NgConfigValues.icons.icons and _NgConfigValues.icons.diagnostic_virtual_text or "" },
   -- Use a function to dynamically turn signs off
   -- and on, using buffer local variables
   signs = true,

--- a/lua/navigator/lspclient/highlight.lua
+++ b/lua/navigator/lspclient/highlight.lua
@@ -25,7 +25,7 @@ function M.diagnositc_config_sign()
                      icons.diagnostic_hint
   if vim.diagnostic ~= nil then
     local t = vim.fn.sign_getdefined('DiagnosticSignWarn')
-    if vim.tbl_isempty(t) or t[1].text == "W " and icons.icons == true then
+    if (vim.tbl_isempty(t) or t[1].text == "W ") and icons.icons == true then
 
       vim.fn.sign_define('DiagnosticSignError',
                          {text = e, texthl = 'DiagnosticError', linehl = '', numhl = ''})
@@ -40,7 +40,7 @@ function M.diagnositc_config_sign()
     end
   else
     local t = vim.fn.sign_getdefined('LspDiagnosticSignWarn')
-    if vim.tbl_isempty(t) or t[1].text == "W " and icons.icons == true then
+    if (vim.tbl_isempty(t) or t[1].text == "W ") and icons.icons == true then
       vim.fn.sign_define('LspDiagnosticsSignError',
                          {text = e, texthl = 'LspDiagnosticsSignError', linehl = '', numhl = ''})
       vim.fn.sign_define('LspDiagnosticsSignWarning',


### PR DESCRIPTION
It makes disabling icons possible. It means that the following configuration option `{ icons={ icons=false }}` will work.
It addresses bug #142  