### PR TITLE
doc(packer): depend on nvim-lspconfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,9 +132,13 @@ Note: Highly recommened: 'nvim-treesitter/nvim-treesitter'
 Packer
 
 ```lua
-
-use {'ray-x/navigator.lua', requires = {'ray-x/guihua.lua', run = 'cd lua/fzy && make'}}
-
+use({
+    'ray-x/navigator.lua',
+    requires = {
+        { 'ray-x/guihua.lua', run = 'cd lua/fzy && make' },
+        { 'neovim/nvim-lspconfig' },
+    },
+})
 ```
 
 ## Setup


### PR DESCRIPTION
I copy&pasted the installation instructions for packer and was greeted with an error that nvim-lspconfig is missing. Easy to fix as it's even mentioned a few lines above, but since the example for vim-plug also adds `neovim/nvim-lspconfig`, I have added it for consistency reasons to the packer section.