### PR TITLE
fix(sumneko): fix incorrect usage of runtime.path

### DIFF
--- a/lua/navigator/lspclient/clients.lua
+++ b/lua/navigator/lspclient/clients.lua
@@ -53,11 +53,6 @@ if ok and l then
   luadev = l.setup(luadevcfg)
 end
 
-local path = vim.split(package.path, ';')
-
-table.insert(path, 'lua/?.lua')
-table.insert(path, 'lua/?/init.lua')
-
 local function add(lib)
   for _, p in pairs(vim.fn.expand(lib, false, true)) do
     p = vim.loop.fs_realpath(p)
@@ -235,8 +230,6 @@ local setups = {
         runtime = {
           -- Tell the language server which version of Lua you're using (most likely LuaJIT in the case of Neovim)
           version = 'LuaJIT',
-          -- Setup your lua path
-          path = vim.split(package.path, ';'),
         },
         diagnostics = {
           enable = true,


### PR DESCRIPTION
This is quite tricky to get right, because there are two ways for
sumneko to search for files, namely:

1. Lua.runtime.path

When using `require`, how to find the file based on the input name.
Setting this config to `?/init.lua` means that when you enter `require
'myfile'`, `${workspace}/myfile/init.lua` will be searched from the
loaded files.  if `runtime.pathStrict` is `false`,
`${workspace}/**/myfile/init.lua` will also be searched.  If you want to
load files outside the workspace, you need to set
`Lua.workspace.library` first.

2. Lua.workspace.library

In addition to the current workspace, which directories will load files
from. The files in these directories will be treated as externally
provided code libraries, and some features (such as renaming fields)
will not modify these files.

The crucial point is that `Lua.runtime.path` only applies to
the *current* workspace. Thus it makes no sense to add any absolute
directories here. Absolute directories must be added to
workspace.library, which is already the case. The default value provided
by sumneko is what you typically would expect, so I have switched to it.

References:

- https://github.com/sumneko/lua-language-server/blob/076dd3e5c4e03f9cef0c5757dfa09a010c0ec6bf/locale/en-us/setting.lua#L5-L13
- https://github.com/sumneko/lua-language-server/blob/e62d964ff57cc0b37eb908315f9afe3ce6a213d7/script/config/config.lua#L151