### PR TITLE
using vim.keymap.set, breaking changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,8 +257,8 @@ require'navigator'.setup({
   -- end,
   -- The attach code will apply to all LSP clients
 
-  default_mapping = true,  -- set to false if you will remap every key
-  keymaps = {{key = "gK", func = "declaration()"}}, -- a list of key maps
+  default_mapping = true,  -- set to false if you will remap every key or if you using old version of nvim-
+  keymaps = {{key = "gK", func = vim.lsp.declaration, doc = 'declaration'}}, -- a list of key maps
   -- this kepmap gK will override "gD" mapping function declaration()  in default kepmap
   -- please check mapping.lua for all keymaps
   treesitter_analysis = true, -- treesitter variable context

--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@ require'navigator'.setup({
   signature_help_cfg = nil, -- if you would like to init ray-x/lsp_signature plugin in navigator, and pass in your own config to signature help
   icons = {
     -- Code action
-    code_action_icon = "🏏",
+    code_action_icon = "🏏", -- note: need terminal support, for those not support unicode, might crash
     -- Diagnostics
     diagnostic_head = '🐛',
     diagnostic_head_severity_1 = "🈲",

--- a/lua/navigator.lua
+++ b/lua/navigator.lua
@@ -5,7 +5,9 @@ local function warn(msg)
 end
 
 local function info(msg)
-  vim.api.nvim_echo({ { 'Info: ' .. msg } }, true, {})
+  if _NgConfigValues.debug then
+    vim.api.nvim_echo({ { 'Info: ' .. msg } }, true, {})
+  end
 end
 
 _NgConfigValues = {
@@ -16,7 +18,7 @@ _NgConfigValues = {
   preview_lines = 40, -- total lines in preview screen
   preview_lines_before = 5, -- lines before the highlight line
   default_mapping = true,
-  keymaps = {}, -- e.g keymaps={{key = "GR", func = "references()"}, } this replace gr default mapping
+  keymaps = {}, -- e.g keymaps={{key = "GR", func = vim.lsp.buf.references}, } this replace gr default mapping
   external = nil, -- true: enable for goneovim multigrid otherwise false
 
   border = 'single', -- border style, can be one of 'none', 'single', 'double', "shadow"
@@ -204,7 +206,7 @@ local extend_config = function(opts)
                   info(string.format('[] extend LSP support for  %s %s ', key, k))
                 end
               elseif key == 'keymaps' then
-                info('keymap override')
+                info('keymap override', v)
                 -- skip key check and allow mapping to handle that
               else
                 warn(string.format('[] Key %s %s not valid', key, k))

--- a/lua/navigator/formatting.lua
+++ b/lua/navigator/formatting.lua
@@ -31,4 +31,16 @@ return {
       end
     end, 100)
   end,
+  range_foramt = function(err, result, ctx, _)
+    local old_func = vim.go.operatorfunc
+    _G.op_func_formatting = function()
+      local start = vim.api.nvim_buf_get_mark(0, '[')
+      local finish = vim.api.nvim_buf_get_mark(0, ']')
+      vim.lsp.buf.range_formatting({}, start, finish)
+      vim.go.operatorfunc = old_func
+      _G.op_func_formatting = nil
+    end
+    vim.go.operatorfunc = 'v:lua.op_func_formatting'
+    vim.api.nvim_feedkeys('g@', 'n', false)
+  end,
 }

--- a/lua/navigator/lspclient/mapping.lua
+++ b/lua/navigator/lspclient/mapping.lua
@@ -1,13 +1,8 @@
 local util = require('navigator.util')
 local log = util.log
 local trace = util.trace
-<<<<<<< HEAD
 local api = vim.api
 
-||||||| 91d1366
-
-=======
->>>>>>> master
 local event_hdlrs = {
   { ev = 'BufWritePre', func = require('navigator.diagnostics').set_diag_loclist },
   { ev = { 'CursorHold', 'CursorHoldI' }, func = vim.lsp.buf.document_highlight },

--- a/lua/navigator/lspclient/mapping.lua
+++ b/lua/navigator/lspclient/mapping.lua
@@ -24,7 +24,7 @@ local key_maps = {
   { key = 'gr', func = require('navigator.reference').async_ref, doc = 'async_ref' },
   { key = '<Leader>gr', func = require('navigator.reference').reference, doc = 'reference' }, -- reference deprecated
   { mode = 'i', key = '<M-k>', func = vim.lsp.signature_help, doc = 'signature_help' },
-  { key = '<c-k>', func = 'signature_help()' },
+  { key = '<c-k>', func = vim.lsp.buf.signature_help, doc = 'signature_help' },
   { key = 'g0', func = require('navigator.symbols').document_symbols, doc = 'document_symbols' },
   { key = 'gW', func = require('navigator.workspace').workspace_symbol_live, doc = 'workspace_symbol_live' },
   { key = '<c-]>', func = require('navigator.definition').definition, doc = 'definition' },
@@ -180,7 +180,7 @@ local function set_mapping(lsp_info)
   local fmtkey, rfmtkey
   for _, value in pairs(key_maps) do
     if type(value.func) == 'string' then -- deprecated will remove when 0.8 is out
-      vim.notify('keymap config updated: func should be a function')
+      vim.notify('keymap config updated: ' .. value.key .. ' func ' .. value.func .. ' should be a function')
       local f = '<Cmd>lua vim.lsp.buf.' .. value.func .. '<CR>'
       if string.find(value.func, 'require') or string.find(value.func, 'vim.') then
         f = '<Cmd>lua ' .. value.func .. '<CR>'

--- a/playground/init.lua
+++ b/playground/init.lua
@@ -47,6 +47,8 @@ local function load_plugins()
         config = function()
           require('navigator').setup({
             lsp_signature_help = true,
+            debug = true,
+            keymaps = { { key = 'gK', func = vim.lsp.buf.definition, doc = 'definition' } },
           })
         end,
       })


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1681295/176980849-c527764c-dd10-4530-9125-ae44fe03b2c1.png)

Moving to new neovim API for key binding

The new way to bind a key is 
`  { key = 'gr', func = require('navigator.reference').async_ref, doc = 'async_ref' }, `
doc field is optional
Also as vim.keymap.set() only supported 0.7.x and greater so 0.6.x might no longer works.

Benefits:
1) will not deprecate for a while
2) native lua callback

But you may need to update the config if you override default keymappings. The string search will not work
e.g. in old config
`  { key = 'gD', func = 'definition()'}, `
`definition()` is used to replace the internal old mapping 
`  { key = 'gd', func = 'definition()'}, `
and key `gd` will be removed from default config.

The new config
` { key = 'gD', func = vim.lsp.buf.definition}, `
new default:
` { key = 'gd', func = vim.lsp.buf.definition, doc='definition'}, `
It will search if function reference `vim.lsp.buf.definition` matches.
 
