### PR TITLE
fix error mason+ccls, add exceptions to mason

### DIFF
--- a/lua/navigator.lua
+++ b/lua/navigator.lua
@@ -94,6 +94,7 @@ _NgConfigValues = {
   },
   lsp_installer = false, -- set to true if you would like use the lsp installed by williamboman/nvim-lsp-installer
   mason = false, -- set to true if you would like use the lsp installed by williamboman/mason
+  mason_disabled_for = {}, -- disable mason for specified lspclients 
   icons = {
     icons = true, -- set to false to use system default ( if you using a terminal does not have nerd/icon)
     -- Code action

--- a/lua/navigator/lspclient/clients.lua
+++ b/lua/navigator/lspclient/clients.lua
@@ -433,7 +433,18 @@ local function lsp_startup(ft, retry, user_lsp_opts)
         end
       end
     end
-    if has_mason and _NgConfigValues.mason then
+
+    function mason_disabled_for(client)
+      local mdisabled = _NgConfigValues.mason_disabled_for
+      if  #mdisabled > 0 then
+        for _, disabled_client in ipairs(mdisabled) do
+          if disabled_client == client then return true end
+        end
+      end
+      return false
+    end
+
+    if has_mason and _NgConfigValues.mason and not mason_disabled_for(lspconfig[lspclient].name) then
       local servers = require'mason-lspconfig'.get_installed_servers()
       if not vim.tbl_contains(servers, lspconfig[lspclient].name) then
         log('mason server not installed', lspconfig[lspclient].name)


### PR DESCRIPTION
User has the possibility to add exceptions to the clients handled by mason.

This is helpful incase mason is used but a particular LSP server is not handled by mason (like **ccls**)