### PR TITLE
fix automated handling of libraries with sumneko_lua + lua-dev

### DIFF
--- a/lua/navigator/lspclient/sumneko_lua.lua
+++ b/lua/navigator/lspclient/sumneko_lua.lua
@@ -28,7 +28,9 @@ local sumneko_cfg = {
     },
   },
   on_new_config = function(cfg, root)
-    local libs = vim.tbl_deep_extend('force', {}, library)
+    local libs = vim.schedule(function()
+      vim.tbl_deep_extend('force', {}, library)
+    end)
     libs[root] = nil
     cfg.settings.Lua.workspace.library = libs
     return cfg


### PR DESCRIPTION
- I realized that luadev configuration that was injected in luadev was getting overriden by the `on_new_config` behavior. It took me time to understand what was going as the logs show the custom `lua-dev` config being loaded and `lspconfig.setup()` using the right config, then later on the logs show that a new config is applied based on the default config inside `sumneko_lua.lua` . It turned out `on_new_config` was the culprit. I encapsulated the call in `vim.schedule` and everything is working perfectly now however I am not sure if this is the right way to do it. 
- 
- This also fixes auto completion with native vim api using lua-dev and nvim-cmp (also complements #229)