### PR TITLE
Fix: Remove deprecated rust-analyzer settings

### DIFF
--- a/lua/navigator/lspclient/clients_default.lua
+++ b/lua/navigator/lspclient/clients_default.lua
@@ -113,7 +113,6 @@ M.defaults = function()
       on_attach = on_attach,
       settings = {
         ['rust-analyzer'] = {
-          assist = { importMergeBehavior = 'last', importPrefix = 'by_self' },
           cargo = { loadOutDirsFromCheck = true },
           procMacro = { enable = true },
         },


### PR DESCRIPTION
Fixes #243

Hope that is the right way to fix it. The error message disappeared for me.