### PR TITLE
Fix typo in 'disply_diagnostic_qf'

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,7 +336,7 @@ require'navigator'.setup({
                                                  --                for other style, set to {'╍', 'ﮆ'} or {'-', '='}
     diagnostic_virtual_text = true,  -- show virtual for diagnostic message
     diagnostic_update_in_insert = false, -- update diagnostic message in insert mode
-    disply_diagnostic_qf = true, -- always show quickfix if there are diagnostic errors, set to false if you want to ignore it
+    display_diagnostic_qf = true, -- always show quickfix if there are diagnostic errors, set to false if you want to ignore it
     tsserver = {
       filetypes = {'typescript'} -- disable javascript etc,
       -- set to {} to disable the lspclient for all filetypes

--- a/doc/navigator.txt
+++ b/doc/navigator.txt
@@ -316,7 +316,7 @@ Nondefault configuration example:
         -- for other style, set to {'╍', 'ﮆ'} or {'-', '='}
         diagnostic_virtual_text = true,  -- show virtual for diagnostic message
         diagnostic_update_in_insert = false, -- update diagnostic message in insert mode
-        disply_diagnostic_qf = true, -- always show quickfix if there are diagnostic errors, set to false if you  want to
+        display_diagnostic_qf = true, -- always show quickfix if there are diagnostic errors, set to false if you  want to
         ignore it
         tsserver = {
           filetypes = {'typescript'} -- disable javascript etc,

--- a/lua/navigator.lua
+++ b/lua/navigator.lua
@@ -124,7 +124,7 @@ _NgConfigValues = {
     disable_format_cap = {}, -- a list of lsp disable file format (e.g. if you using efm or vim-codeformat etc), empty by default
     disable_lsp = {}, -- a list of lsp server disabled for your project, e.g. denols and tsserver you may
     -- only want to enable one lsp server
-    disply_diagnostic_qf = true, -- always show quickfix if there are diagnostic errors
+    display_diagnostic_qf = true, -- always show quickfix if there are diagnostic errors
     diagnostic_load_files = false, -- lsp diagnostic errors list may contains uri that not opened yet set to true
     -- to load those files
     diagnostic_virtual_text = true, -- show virtual for diagnostic message

--- a/lua/navigator/diagnostics.lua
+++ b/lua/navigator/diagnostics.lua
@@ -437,7 +437,7 @@ M.setloclist = function(bufnr)
 
   if not vim.tbl_isempty(vim.lsp.get_active_clients({ buffer = bufnr })) then
     local err_cnt = get_count(0, [[Error]])
-    if err_cnt > 0 and _NgConfigValues.lsp.disply_diagnostic_qf then
+    if err_cnt > 0 and _NgConfigValues.lsp.display_diagnostic_qf then
       cfg.namespaces = diagnostic.get_namespaces()
       diagnostic.setloclist(cfg)
     else


### PR DESCRIPTION
Took me a while to realize why the diagnostics qf was still being displayed, there was a typo in the option. Don't know if this is something you wish to merge, feel free to close it.
Great plugin! :heart: