### PR TITLE
fix error on execute `:source <init.vim-path>`

### DIFF
--- a/lua/navigator/lspclient/clients.lua
+++ b/lua/navigator/lspclient/clients.lua
@@ -62,10 +62,6 @@ local has_lspinst = false
 local has_mason = false
 
 
-if config.lsp.disable_lsp == 'all' then
-  config.lsp.disable_lsp = servers
-end
-
 local ng_default_cfg = {
   on_attach = on_attach,
   flags = { allow_incremental_sync = true, debounce_text_changes = 1000 },
@@ -522,6 +518,10 @@ local ft_map = {
 }
 
 local function setup(user_opts)
+  if config.lsp.disable_lsp == 'all' then
+    config.lsp.disable_lsp = servers
+  end
+
   user_opts = user_opts or {}
   local bufnr = user_opts.bufnr or vim.api.nvim_get_current_buf()
 


### PR DESCRIPTION
Error occurs when `disable_lsp = "all"` is set.
```
Error executing vim.schedule lua callback: vim/shared.lua:0: t: expected table, got string
stack traceback:
        [C]: in function 'error'
        vim/shared.lua: in function 'validate'
        vim/shared.lua: in function 'tbl_contains'
        ...lugged/navigator.lua/lua/navigator/lspclient/clients.lua:257: in function 'lsp_startup'
        ...lugged/navigator.lua/lua/navigator/lspclient/clients.lua:604: in function 'setup'
        /home/kbwo/.vim/plugged/navigator.lua/lua/navigator.lua:322: in function ''
        vim/_editor.lua: in function ''
        vim/_editor.lua: in function <vim/_editor.lua:0>
```

Minimal vim configuraiton to test this error
```
set rtp +=~/.vim
if !filereadable(expand('~/.vim/autoload/plug.vim'))
  echo "Installing Vim-Plug..."
  echo ""
  silent !\curl -fLo ~/.vim/autoload/plug.vim --create-dirs https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim
  let g:not_finish_vimplug = "yes"
  autocmd VimEnter * PlugInstall
endif

call plug#begin('~/.vim/plugged')

Plug 'neovim/nvim-lspconfig'
Plug 'ray-x/guihua.lua', {'do': 'cd lua/fzy && make' }
Plug 'ray-x/navigator.lua'

call plug#end()

" No need for require('lspconfig'), navigator will configure it for you
lua <<EOF
require 'navigator'.setup({
  lsp = {
    disable_lsp = "all",
  },
})

```

I fixed this error by moving `config.lsp.disable_lsp = servers` into `lspclient.clients.setup`
