### PR TITLE
Fixes for various problems relating to treesitter interactions and upstream changes

### DIFF
--- a/lua/navigator/cclshierarchy.lua
+++ b/lua/navigator/cclshierarchy.lua
@@ -4,7 +4,7 @@ local log = util.log
 local partial = util.partial
 local lsphelper = require('navigator.lspwrapper')
 local uv = vim.uv or vim.loop
-local cwd = vim.loop.cwd()
+local cwd = uv.cwd()
 
 local path_sep = require('navigator.util').path_sep()
 local path_cur = require('navigator.util').path_cur()

--- a/lua/navigator/definition.lua
+++ b/lua/navigator/definition.lua
@@ -75,7 +75,7 @@ local function def_preview(timeout_ms, method)
   -- result = {vim.tbl_deep_extend("force", {}, unpack(result))}
   -- log("def-preview", result)
   for _, value in pairs(result) do
-    if value ~= nil and not vim.tbl_isempty(value.result) then
+    if value ~= nil and value.result ~= nil and not vim.tbl_isempty(value.result) then
       table.insert(data, value.result[1])
     end
   end

--- a/lua/navigator/treesitter.lua
+++ b/lua/navigator/treesitter.lua
@@ -228,7 +228,8 @@ local function get_definitions(bufnr)
   local local_nodes = ts_locals.get_locals(bufnr)
   -- Make sure the nodes are unique.
   local nodes_set = {}
-  for _, loc in ipairs(local_nodes) do
+  for _, nodes in ipairs(local_nodes) do
+    local loc = nodes["local"]
     trace(loc)
     if loc.definition then
       ts_locals.recurse_local_nodes(loc.definition, function(_, node, _, match)

--- a/playground/init.lua
+++ b/playground/init.lua
@@ -1,5 +1,6 @@
 vim.cmd([[set runtimepath=$VIMRUNTIME]])
-local os_name = vim.loop.os_uname().sysname
+local uv = vim.uv or vim.loop
+local os_name = uv.os_uname().sysname
 
 local is_windows = os_name == 'Windows' or os_name == 'Windows_NT'
 
@@ -26,7 +27,7 @@ local plugin_folder = function()
 end
 
 local lazypath = package_root .. sep .. 'lazy.nvim'
-if not vim.loop.fs_stat(lazypath) then
+if not uv.fs_stat(lazypath) then
   vim.fn.system({
     'git',
     'clone',

--- a/thread.lua
+++ b/thread.lua
@@ -17,4 +17,5 @@ local func = function(p, uv)
   assert(elapsed >= 1000, "elapsed should be at least delay ")
 end
 
-func(print, vim.loop)
+local uv = vim.uv or vim.loop
+func(print, uv)


### PR DESCRIPTION
This should fix #299 as well.

When trying to view treesitter symbols (e.g. via `:TSymbols`) no results would appear in the side panel due to the treesitter nodes now being located in a subtable in the query results. Fixed via drilling down into the subtable ("local") before processing the node types.

When using the (deprecated) reference request - default `<leader>gr` - there would be errors regarding nil references due to some undefined variables being used as parameters. Simply defining them wasn't sufficient either, as further down the callstack (inside treesitters `parser` code) there's functions that aren't allowed to be run inside the async loop routines. I ended up taking all of that out and just calling `warmup_treesitter` directly, as the async_ref version of this command should be used anyway.

I also quickly went through and replaced the rest of the direct references to `vim.loop` with `vim.uv` (if available) that seemed to have been missed the first time around.