### PR TITLE
add ability to configure code actions that trigger sign/virtual text

### DIFF
--- a/lua/navigator.lua
+++ b/lua/navigator.lua
@@ -61,7 +61,7 @@ _NgConfigValues = {
       sign_priority = 40,
       virtual_text = true,
       virtual_text_icon = true,
-      only = {},
+      exclude = {},
     },
     rename = {
       enable = true,

--- a/lua/navigator.lua
+++ b/lua/navigator.lua
@@ -61,6 +61,7 @@ _NgConfigValues = {
       sign_priority = 40,
       virtual_text = true,
       virtual_text_icon = true,
+      only = {},
     },
     rename = {
       enable = true,

--- a/lua/navigator/codeAction.lua
+++ b/lua/navigator/codeAction.lua
@@ -225,7 +225,7 @@ code_action.code_action_prompt = function(bufnr, only)
     context.only = only
   end
 
-  log('using code action context', context)
+  log('using code action context for prompt', context)
 
   local winid = get_current_winid()
   code_action[winid] = code_action[winid] or {}

--- a/lua/navigator/codeAction.lua
+++ b/lua/navigator/codeAction.lua
@@ -147,12 +147,11 @@ local action_virtual_call_back = function(line, diagnostics)
   return code_action:render_action_virtual_text(line, diagnostics)
 end
 
-local code_action_req = function(_call_back_fn, diagnostics)
-  local context = { diagnostics = diagnostics }
+local code_action_req = function(_call_back_fn, context)
   local params = vim.lsp.util.make_range_params()
   params.context = context
   local line = params.range.start.line
-  local callback = _call_back_fn(line, diagnostics)
+  local callback = _call_back_fn(line, context.diagnostics)
   vim.lsp.buf_request(0, 'textDocument/codeAction', params, callback)
 end
 
@@ -203,7 +202,7 @@ code_action.range_code_action = function(startpos, endpos)
   end, 1000)
 end
 
-code_action.code_action_prompt = function(bufnr)
+code_action.code_action_prompt = function(bufnr, only)
   if special_buffers[vim.bo.filetype] then
     log('skip buffer', vim.bo.filetype)
     return
@@ -218,10 +217,20 @@ code_action.code_action_prompt = function(bufnr)
     diagnostics = diagnostic.get(vim.api.nvim_get_current_buf(), { lnum = lnum })
   end
 
+  local context = {
+    diagnostics = diagnostics,
+  }
+
+  if next(only) then
+    context.only = only
+  end
+
+  log('using code action context', context)
+
   local winid = get_current_winid()
   code_action[winid] = code_action[winid] or {}
   code_action[winid].lightbulb_line = code_action[winid].lightbulb_line or 0
-  code_action_req(action_virtual_call_back, diagnostics)
+  code_action_req(action_virtual_call_back, context)
 end
 
 return code_action

--- a/lua/navigator/lspclient/attach.lua
+++ b/lua/navigator/lspclient/attach.lua
@@ -74,12 +74,22 @@ M.on_attach = function(client, bufnr)
 
   if _NgConfigValues.lsp.code_action.enable then
     if client.server_capabilities.codeActionProvider and client.name ~= 'null-ls' then
+
+      local kinds = {}
+      if client.server_capabilities.codeActionProvider.codeActionKinds then
+        for _, kind in ipairs(client.server_capabilities.codeActionProvider.codeActionKinds) do
+          if not vim.tbl_contains(_NgConfigValues.lsp.code_action.exclude, kind) then
+            table.insert(kinds, kind)
+          end
+        end
+      end
+
       trace('code action enabled for client', client.server_capabilities.codeActionProvider)
       api.nvim_create_autocmd({ 'CursorHold', 'CursorHoldI' }, {
         group = api.nvim_create_augroup('NGCodeActGroup_' .. tostring(bufnr), {}),
         buffer = bufnr,
         callback = function()
-          require('navigator.codeAction').code_action_prompt(bufnr, _NgConfigValues.lsp.code_action.only)
+        require('navigator.codeAction').code_action_prompt(bufnr, kinds)
         end,
       })
     end

--- a/lua/navigator/lspclient/attach.lua
+++ b/lua/navigator/lspclient/attach.lua
@@ -79,7 +79,7 @@ M.on_attach = function(client, bufnr)
         group = api.nvim_create_augroup('NGCodeActGroup_' .. tostring(bufnr), {}),
         buffer = bufnr,
         callback = function()
-          require('navigator.codeAction').code_action_prompt(bufnr)
+          require('navigator.codeAction').code_action_prompt(bufnr, _NgConfigValues.lsp.code_action.only)
         end,
       })
     end


### PR DESCRIPTION
This PR adds a configuration option to the `lsp.code_action` section of the config to specify which code actions to exclude for triggering the sign and virtual text for.

The problem this solves is that, at least with `gopls`, there is a `source.documentation` code action that shows up for pretty much every line. This makes the sign and virtual text useless and noisy. The `codeActions` LSP call accepts an `only` parameter, setting this to a subset of the actions allows me to filter out the `source.documenation` action. The default is an empty table which will preserve the existing behavior.

I'm not sure if we want this exposed per language server, not sure how to plumb that in if so?

Here's some additional context on the problem this is solving: https://github.com/golang/go/issues/68783