### PR TITLE
`tsserver` is deprecated, should use `ts_ls`

### DIFF
--- a/lua/navigator/lspclient/servers.lua
+++ b/lua/navigator/lspclient/servers.lua
@@ -1,7 +1,7 @@
 return {
   'angularls',
   'gopls',
-  'tsserver',
+  'ts_ls',
   'flow',
   'bashls',
   'dockerls',


### PR DESCRIPTION
fix(`tsserver`): Fix tsserver deprication by moving `tsserver` to `ts_ls`.

I believe this closes issue #313.