### PR TITLE
fix: correctly determine diagnostic enabled state for toggling

### DIFF
--- a/lua/navigator/diagnostics.lua
+++ b/lua/navigator/diagnostics.lua
@@ -433,7 +433,7 @@ M.hide_diagnostic = function()
 end
 
 M.toggle_diagnostics = function()
-  M.diagnostic_enabled = not vim.diagnostic.enable()
+  M.diagnostic_enabled = not vim.diagnostic.is_enabled()
   vim.diagnostic.enable(M.diagnostic_enabled)
 end
 


### PR DESCRIPTION
Toggling diagnostics doesn't work due to an incorrectly used function always resulting in a true value. Correctly retrieving the current state makes the toggle work as expected.