### PR TITLE
remove conflicting code

### DIFF
--- a/lua/navigator/definition.lua
+++ b/lua/navigator/definition.lua
@@ -77,15 +77,10 @@ local function def_preview(timeout_ms, method)
     return
   end
 
-  if not vim.islist(result) then
-    log('no result found')
-    return
-  end
-
   log(result)
+
   local data = {}
-  -- result = {vim.tbl_deep_extend("force", {}, unpack(result))}
-  -- log("def-preview", result)
+
   for _, value in pairs(result) do
     if value ~= nil and value.result ~= nil and not vim.tbl_isempty(value.result) then
       table.insert(data, value.result[1])


### PR DESCRIPTION
Hey, I just found a problem with the `def_preview` function. When you have "multiple" lsp's attached in a buffer, this breaks.

You have "multiple" lsp's when you have something like `copilot` or other code assistants like this:
![image](https://github.com/user-attachments/assets/72365bee-b8cb-4b28-ba39-9f36061d6c01)
Or even when you are working in a project that involves multiple lsp's.

In this case, my active clients for current buffer are two with some "random" `id`. So, when I try to call `definition_preview` my `result` table ended looking like this
```
{                                                                                                                                                                                                                   
  [3] = {                                                                                                                                                                                                           
    result = { {                                                                                                                                                                                                    
        range = {                                                                                                                                                                                                   
          ["end"] = {                                                                                                                                                                                               
            character = 19,                                                                                                                                                                                         
            line = 27                                                                                                                                                                                               
          },                                                                                                                                                                                                        
          start = {                                                                                                                                                                                                 
            character = 14,                                                                                                                                                                                         
            line = 27                                                                                                                                                                                               
          }                                                                                                                                                                                                         
        },                                                                                                                                                                                                          
        uri = "file:///home/ddaniel27/.local/share/nvim/lazy/navigator.lua/playground/go/interface.go"                                                                                                              
      } }                                                                                                                                                                                                           
  }                                                                                                                                                                                                                 
} 
```
And because `vim.islist` can't handle this scenario, will trigger [this piece of code](https://github.com/ray-x/navigator.lua/blob/452d47ba82655be4fc8e1d9c24dccb304f24f7df/lua/navigator/definition.lua#L80-L83)

```
  if not vim.islist(result) then
    log('no result found')
    return
  end
```
And no preview is showed.

I found this was implemented in [this fix](https://github.com/ray-x/navigator.lua/commit/633c7da38f2479d23f11a93ef70609d902fc30c7) for [this issue](https://github.com/ray-x/navigator.lua/issues/73) about calling get preview in a blank line or not preview found, but I notice that you are already handling that scenario below [here](https://github.com/ray-x/navigator.lua/blob/452d47ba82655be4fc8e1d9c24dccb304f24f7df/lua/navigator/definition.lua#L95-L98)

```
  if vim.tbl_isempty(data) then
    vim.notify('No result found: ' .. method, vim.log.levels.WARN)
    return
  end
  ```
  
  So, if this code is removed, this will be the result:
  
![image](https://github.com/user-attachments/assets/4e550d6a-2cea-42c9-a203-ba21815053cb)
Expected result when calling `definition_preview`


![image](https://github.com/user-attachments/assets/5540f31f-a071-40e1-8c67-d4e07548754f)
notification when calling a preview in a blank line

![image](https://github.com/user-attachments/assets/a6eaae2e-592f-4550-a75a-417e2862a5f6)
notification when calling a preview when no preview found

Let me know if more information or testing is needed!
