### PR TITLE
updated hover handler to use border

### DIFF
--- a/lua/navigator/lspclient/mapping.lua
+++ b/lua/navigator/lspclient/mapping.lua
@@ -25,8 +25,6 @@ local function fallback_fn(key)
   end
 end
 
-local double = { '╔', '═', '╗', '║', '╝', '═', '╚', '║' }
-local single = { '╭', '─', '╮', '│', '╯', '─', '╰', '│' }
 local remap = util.binding_remap
 -- stylua: ignore start
 local key_maps = {
@@ -73,7 +71,7 @@ local key_maps = {
 }
 
 if _NgConfigValues.lsp.hover then
-  table.insert(key_maps, { key = 'K', func = vim.lsp.buf.hover, desc = 'hover' })
+  table.insert(key_maps, { key = 'K', func = require('navigator.hover').hover, desc = 'hover' })
 end
 
 local key_maps_help = {}
@@ -449,15 +447,6 @@ function M.setup(attach_opts)
     end,
   })
 
-  local border_style = single
-  if _NgConfigValues.border == 'double' then
-    border_style = double
-  end
-  if _NgConfigValues.lsp.hover.enable then
-    vim.lsp.handlers['textDocument/hover'] = util.lsp_with(require('navigator.hover').handler, {
-      border = border_style,
-    })
-  end
   if cap.documentFormattingProvider then
     log('formatting enabled setup hdl')
     vim.lsp.handlers['textDocument/formatting'] = require('navigator.formatting').format_hdl

--- a/lua/navigator/lspwrapper.lua
+++ b/lua/navigator/lspwrapper.lua
@@ -126,6 +126,16 @@ local function extract_result(results_lsp)
   end
 end
 
+local function extract_result_single(results_lsp)
+  if results_lsp then
+    for _, server_results in pairs(results_lsp) do
+      if server_results.result then
+        return server_results.result
+      end
+    end
+  end
+end
+
 function M.check_capabilities(feature, bufnr)
   local clients = lsp.get_clients({ buffer = bufnr or vim.api.nvim_get_current_buf() })
 
@@ -154,6 +164,23 @@ function M.call_sync(method, params, opts, handler)
     lsp.buf_request_sync(opts.bufnr or 0, method, params, opts.timeout or 1000)
 
   return handler(err, extract_result(results_lsp), { method = method, no_show = opts.no_show }, nil)
+end
+
+function M.call_sync_single(method, params, opts, handler)
+  params = params or {}
+  opts = opts or {}
+  local bufnr = opts.bufnr or 0
+  log(method, params)
+  local ctx = {
+    method = method,
+    no_show = opts.no_show,
+    bufnr = bufnr,
+  }
+
+  local results_lsp, err =
+    lsp.buf_request_sync(opts.bufnr or 0, method, params, opts.timeout or 1000)
+
+  return handler(err, extract_result_single(results_lsp), ctx, nil)
 end
 
 function M.call_async(method, params, handler, bufnr)


### PR DESCRIPTION
Hey, since [your comment](https://github.com/ray-x/navigator.lua/pull/323#issuecomment-2817114238) about the border for the preview hover, I've been searching about this and I found a way to make it works again.

![image](https://github.com/user-attachments/assets/4fa9ca06-8b4d-4499-8c93-548fe51d049b)
Please, feel free to do any changes to this PR or even close it if you have any plans to deal with this but with another approach.

I created a some new functions to deal with some data types but I'm not good at `lua` at all and also I'm very new at neovim apis, so please, check this and let me know any thoughts.

PD: I figured out that with new api in nvim 0.11 you can make something like

```lua
          {
            key = 'K',
            func = function()
              vim.lsp.buf.hover({
                border = border_style
              })
            end,
            desc = 'hover'
          }
```
But since I saw this plugin is still compatible with 0.10 (and maybe 0.9 ?) I think this PR is compatible too with those versions since it's not using anything ""new""