### PR TITLE
fix codeaction title

### DIFF
--- a/lua/navigator/codeAction.lua
+++ b/lua/navigator/codeAction.lua
@@ -159,10 +159,16 @@ local function sort_select(action_tuples, opts, on_user_choice)
   opts.width = config.width
   opts.format_item = function(item)
     local action = item.action or item
+    local title = action.title or (action.command and action.command.title) or ''
+
+    if title ~= '' then
+      return title
+    end
+
     local kind = action.kind and ('[' .. action.kind .. '] ') or ''
-    local title = action.command and action.command.title or ''
-    return kind .. title
+    return kind
   end
+
   trace(action_tuples)
   require('guihua.gui').select(action_tuples, opts, on_user_choice)
 end


### PR DESCRIPTION
Hey there! After I updated my plugins, I found a little inconsistency with code actions pop-up vs before. When you call `require('navigator.codeAction').code_action` only the `kind` is returned, but not the title. Check the image:
<img width="909" height="186" alt="image" src="https://github.com/user-attachments/assets/f5d5a019-617a-4043-a5b8-7f788d5aee1e" />
*Sorry for the blue highlight, working on fix everything after the update lol*

I liked how it was before with the title, so I updated it and shows like this:
<img width="935" height="173" alt="image" src="https://github.com/user-attachments/assets/20af9e4f-c12e-4569-8ecc-b787562cac9f" />

I'm using the title (that according with [the spec](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_codeAction) is required), but if not, falls back to command title, if not, just return the kind as before.

I'm not sure if that change was expected, if so, feel free to close/edit or do whatever with this PR.

As always, thanks for your work on this plugin! :)